### PR TITLE
Remove call to `Kernel#open`

### DIFF
--- a/ciphersuites.rb
+++ b/ciphersuites.rb
@@ -9,7 +9,7 @@ output = {
   '00FF' => 'TLS_EMPTY_RENEGOTIATION_INFO_SCSV'
 }
 
-open('https://ciphersuite.info/api/cs/') do |f|
+URI.open('https://ciphersuite.info/api/cs/') do |f|
   content = File.read(f)
   data = JSON.parse(content)
 


### PR DESCRIPTION
At some point, calling `Kernel#open` for a URI has been deprecated:

  warning: calling URI.open via Kernel#open is deprecated, call
  URI.open directly or use URI#open

so change the call explicitly to `URI.open`